### PR TITLE
Create a plain package with no sources/javadocs

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -6,6 +6,10 @@ on:
   # trigger when starred
   watch:
     types: [started]  
+    
+env:
+  USERNAME: token
+  TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   publish:
@@ -16,6 +20,3 @@ jobs:
     - run: ./gradlew publish
     - run: ./gradlew publish
     - run: ./gradlew publish
-      env:
-        USERNAME: token
-        TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -17,4 +17,4 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - run: ./gradlew publish
+    - run: ./gradlew publish -b build.gradle.kts

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: ./gradlew publish
+    - run: ./gradlew publish
+    - run: ./gradlew publish
       env:
         USERNAME: token
         TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,5 +18,3 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: ./gradlew publish
-    - run: ./gradlew publish
-    - run: ./gradlew publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,10 @@ repositories {
     jcenter()
 }
 
-group = "org.test"
+group = "org.test.plain"
 version = "1.0-SNAPSHOT"
 
 java {
-    withJavadocJar()
-    withSourcesJar()
 }
 
 val sourcesJar by tasks.getting(Jar::class)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,9 +11,6 @@ repositories {
 group = "org.test.plain"
 version = "1.0-SNAPSHOT"
 
-java {
-}
-
 dependencies {
     api("org.apache.commons:commons-math3:3.6.1")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,9 +14,6 @@ version = "1.0-SNAPSHOT"
 java {
 }
 
-val sourcesJar by tasks.getting(Jar::class)
-sourcesJar.exclude("*.txt")
-
 dependencies {
     api("org.apache.commons:commons-math3:3.6.1")
 


### PR DESCRIPTION
What this PR does:

- Don't include `javadoc.jar`
- Don't include `sources.jar`
- Explicitly target `build.gradle.kts`
- Change `group` to `org.test.plain`

